### PR TITLE
Add(env): Add environment variable to enable remount feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CSI driver implementation for OpenEBS CStor storage engine.
 This project is under active development and considered to be in Alpha state.
 
 The current implementation supports the following for CStor Volumes:
-1. Provisioning and De-provisioning
+1. Provisioning and De-provisioning with ext4 filesystems
 2. Snapshots and clones
 3. Volume Expansion
 
@@ -187,7 +187,7 @@ be seen in running state.
 
 #### Notes:
 - Only dynamically provisioned volumes can be resized.
-- You can only resize volumes containing a file system if the file system is XFS, Ext3, or Ext4.
+- You can only resize volumes containing a file system if the file system is ext4.
 - Make sure that the storage class has the `allowVolumeExpansion` field set to `true` when the volume is provisioned.
 
 #### Steps:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ openebs-csi-node-56t5g     2/2     Running   0          6m13s
    apiVersion: storage.k8s.io/v1
    metadata:
      name: openebs-csi-cstor-sparse
-   provisioner: openebs-csi.openebs.io
+   provisioner: cstor.csi.openebs.io
    allowVolumeExpansion: true
    parameters:
      cas-type: cstor

--- a/pkg/service/v1alpha1/service.go
+++ b/pkg/service/v1alpha1/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"os"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	config "github.com/openebs/cstor-csi/pkg/config/v1alpha1"
@@ -90,7 +92,10 @@ func New(config *config.Config) *CSIDriver {
 		// becomes read only (in case of RW mount
 		// points), this thread will fetch the path
 		// and relogin or remount
-		// go utils.MonitorMounts()
+		if os.Getenv("REMOUNT") == "true" {
+			logrus.Infof("Monitoring mounts")
+			go utils.MonitorMounts()
+		}
 
 		driver.ns = NewNode(driver)
 	}


### PR DESCRIPTION
To enable the auto remount feature when the volume goes into read only mode, REMOUNT env can be added to the csi node driver section in csi operator yaml:
```
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: openebs-cstor-csi-node
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app: openebs-cstor-csi-node
  template:
    metadata:
      labels:
        app: openebs-cstor-csi-node
        role: openebs-cstor-csi
    spec:
      priorityClassName: system-node-critical
      serviceAccount: openebs-cstor-csi-node-sa
      hostNetwork: true
      containers:
        - name: csi-node-driver-registrar
          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
          imagePullPolicy: IfNotPresent
          args:
            - "--v=5"
            - "--csi-address=$(ADDRESS)"
            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
          lifecycle:
            preStop:
              exec:
                command: ["/bin/sh", "-c", "rm -rf /registration/cstor.csi.openebs.io /registration/cstor.csi.openebs.io-reg.sock"]
          env:
            - name: ADDRESS
              value: /plugin/csi.sock
            - name: DRIVER_REG_SOCK_PATH
              value: /var/lib/kubelet/plugins/cstor.csi.openebs.io/csi.sock
            - name: KUBE_NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: NODE_DRIVER
              value: openebs-cstor-csi
          volumeMounts:
            - name: plugin-dir
              mountPath: /plugin
            - name: registration-dir
              mountPath: /registration
        - name: openebs-csi-plugin
          securityContext:
            privileged: true
            capabilities:
              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
            allowPrivilegeEscalation: true
          image: quay.io/openebs/cstor-csi-driver:ci
          imagePullPolicy: IfNotPresent
          args:
            - "--nodeid=$(OPENEBS_NODE_ID)"
            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
            - "--url=$(OPENEBS_CSI_API_URL)"
            - "--plugin=$(OPENEBS_NODE_DRIVER)"
          env:
            - name: OPENEBS_NODE_ID
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: OPENEBS_CSI_ENDPOINT
              value: unix:///plugin/csi.sock
            - name: OPENEBS_NODE_DRIVER
              value: node
            - name: OPENEBS_API_URL
              value: https://api.openebs.com/
            - name: OPENEBS_MAPI_SVC
              value: maya-apiserver-service
            - name: OPENEBS_NAMESPACE
              value: openebs
            - name: REMOUNT
              value: "true"
          volumeMounts:
            - name: plugin-dir
              mountPath: /plugin
            - name: device-dir
              mountPath: /dev
            - name: pods-mount-dir
              mountPath: /var/lib/kubelet/pods
              # needed so that any mounts setup inside this container are
              # propagated back to the host machine.
              mountPropagation: "Bidirectional"
            - name: iscsiadm-bin
              mountPath: /sbin/iscsiadm
            #Enable the following for Ubuntu 18.04
            - name: iscsiadm-lib-isns-nocrypto
              mountPath: /lib/x86_64-linux-gnu/libisns-nocrypto.so.0
      volumes:
        - name: device-dir
          hostPath:
            path: /dev
            type: Directory
        - name: registration-dir
          hostPath:
            path: /var/lib/kubelet/plugins_registry/
            type: DirectoryOrCreate
        - name: plugin-dir
          hostPath:
            path: /var/lib/kubelet/plugins/cstor.csi.openebs.io/
            type: DirectoryOrCreate
        - name: pods-mount-dir
          hostPath:
            path: /var/lib/kubelet/pods
            type: Directory
        - name: iscsiadm-bin
          hostPath:
            path: /sbin/iscsiadm
            type: File
        #Enable the following for Ubuntu 18.04
        - name: iscsiadm-lib-isns-nocrypto
          hostPath:
            path: /lib/x86_64-linux-gnu/libisns-nocrypto.so.0
            type: File

```