### PR TITLE
Add support for xfs filesystem

### DIFF
--- a/buildscripts/cstor-csi-driver/Dockerfile
+++ b/buildscripts/cstor-csi-driver/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM ubuntu:16.04
 RUN apt-get update; exit 0
-RUN apt-get -y install rsyslog
+RUN apt-get -y install rsyslog xfsprogs
 #RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY cstor-csi-driver /usr/local/bin/


### PR DESCRIPTION
This PR installs xfsprogs inside the container running csi plugin services.
fsType can be added to storage class parameters. Default fsType is ext4
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: cstor-csi-sc
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  cas-type: cstor
  replicaCount: "1"
  cstorPoolCluster: cstor-sparse-cspc
  fsType: xfs
``` 
Signed-off-by: Payes <payes.anand@mayadata.io>