### PR TITLE
refact(size): conversion G to Gi

### DIFF
--- a/pkg/utils/v1alpha1/rounding.go
+++ b/pkg/utils/v1alpha1/rounding.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package utils
 
-import "fmt"
+import (
+	"fmt"
+)
 
 const (
 	unit = 1024
+	// GiB ...
+	GiB = 1024 * 1024 * 1024
 )
 
 // ByteCount converts bytes into corresponding unit
@@ -34,4 +38,39 @@ func ByteCount(b uint64) string {
 	}
 	return fmt.Sprintf("%d%ci",
 		uint64(b)/uint64(div), "KMGTPE"[index])
+}
+
+// RoundUpBytes rounds up the volume size in bytes upto multiplications of GiB
+// in the unit of Bytes
+func RoundUpBytes(volumeSizeBytes int64) int64 {
+	return roundUpSize(volumeSizeBytes, GiB) * GiB
+}
+
+// RoundUpGiB rounds up the volume size in bytes upto multiplications of GiB
+// in the unit of GiB
+func RoundUpGiB(volumeSizeBytes int64) int64 {
+	return roundUpSize(volumeSizeBytes, GiB)
+}
+
+// BytesToGiB converts Bytes to GiB
+func BytesToGiB(volumeSizeBytes int64) int64 {
+	return volumeSizeBytes / GiB
+}
+
+// GiBToBytes converts GiB to Bytes
+func GiBToBytes(volumeSizeGiB int64) int64 {
+	return volumeSizeGiB * GiB
+}
+
+// roundUpSize calculates how many allocation units are needed to accommodate
+// a volume of given size. E.g. when user wants 1500MiB volume, while AWS
+// EBS,GKE etc allocates volumes in gibibyte-sized chunks,
+// RoundUpSize(1500 * 1024*1024, 1024*1024*1024) returns '2'
+// (2 GiB is the smallest allocatable volume that can hold 1500MiB)
+func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
+	roundedUp := volumeSizeBytes / allocationUnitBytes
+	if volumeSizeBytes%allocationUnitBytes > 0 {
+		roundedUp++
+	}
+	return roundedUp
 }


### PR DESCRIPTION
fixes the `G` to `bytes` to `Gi` conversion while trasitioning from PVC to CVC storage capacity the way kubernetes handles, by converting to Gi form.
here is the example link for the same https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/volume/helpers/rounding.go

Note:  roundUpSize calculates how many allocation units are needed to accommodate
a volume of given size. E.g. when user wants 1500MiB volume, while AWS
 EBS,GKE etc allocates volumes in gibibyte-sized chunks,
 RoundUpSize(1500 * 1024*1024, 1024*1024*1024) returns '2'
 (2 GiB is the smallest allocatable volume that can hold 1500MiB)

1. PVC yaml

```yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: claim-csi-123
spec:
  storageClassName: cstor-sparse-auto
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 50G
```

```yaml
$ kubectl get pvc
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
claim-csi-123   Bound    pvc-6ba235b5-2189-4eca-9300-e830c30fc23c   47Gi       RWO            cstor-sparse-auto   30m

$ kubectl get cstorvolume -n openebs
NAME                                       STATUS    AGE   CAPACITY
pvc-6ba235b5-2189-4eca-9300-e830c30fc23c   Healthy   30m   47Gi
```

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>