### PR TITLE
fix(remount): Avoid monitoring volume unless mounted

### DIFF
--- a/pkg/utils/v1alpha1/utils.go
+++ b/pkg/utils/v1alpha1/utils.go
@@ -230,6 +230,10 @@ func MonitorMounts() {
 				break
 			}
 			for _, vol := range csivolList.Items {
+				if (vol.Spec.Volume.StagingTargetPath == "") ||
+					(vol.Spec.Volume.TargetPath == "") {
+					continue
+				}
 				// Search the volume in the list of mounted volumes at the node
 				// retrieved above
 				stagingMountPoint, stagingPathExists := listContains(

--- a/pkg/utils/v1alpha1/utils.go
+++ b/pkg/utils/v1alpha1/utils.go
@@ -230,6 +230,9 @@ func MonitorMounts() {
 				break
 			}
 			for _, vol := range csivolList.Items {
+				// This check is added to avoid monitoring volume if it has not
+				// been mounted yet. Although CSIVolume CR gets created at
+				// ControllerPublish step.
 				if (vol.Spec.Volume.StagingTargetPath == "") ||
 					(vol.Spec.Volume.TargetPath == "") {
 					continue


### PR DESCRIPTION
This PR adds a check in remount for empty staging and publish paths.
The CSIVolume CR creation has been shifted to ControllerPublish from NodePublish.
When CSIVolume CR is created at ControllerPublish, Staging and TargetPath are empty, therefore remount thread should not monitor this volume until a valid staging and targetpath are filled in. These paths are filled in nodeStage and NodePublish APIs.
Signed-off-by: Payes <payes.anand@mayadata.io>