### PR TITLE
fix(unmount): Fix unmount errors for xfs filesystem

### DIFF
--- a/pkg/iscsi/v1alpha1/iscsi_util.go
+++ b/pkg/iscsi/v1alpha1/iscsi_util.go
@@ -467,9 +467,8 @@ func (util *ISCSIUtil) DetachDisk(
 		return err
 	}
 
-	if pathExists, pathErr := mount.PathExists(targetPath); pathErr != nil {
-		return fmt.Errorf("Error checking if path exists: %v", pathErr)
-	} else if !pathExists {
+	pathExists, pathErr := mount.PathExists(targetPath)
+	if pathErr == nil && !pathExists {
 		glog.Warningf(
 			"Warning: Unmount skipped because path does not exist: %v",
 			targetPath,

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -283,7 +283,7 @@ func (ns *node) NodeUnpublishVolume(
 	defer removeVolumeFromTransitionList(volumeID)
 
 	notMnt, err := ns.mounter.IsLikelyNotMountPoint(target)
-	if err == nil && notMnt {
+	if (err == nil && notMnt) || os.IsNotExist(err) {
 		logrus.Warningf("NodeUnpublishVolume: %s is not mounted, err: %v", target, err)
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -283,13 +283,8 @@ func (ns *node) NodeUnpublishVolume(
 	defer removeVolumeFromTransitionList(volumeID)
 
 	notMnt, err := ns.mounter.IsLikelyNotMountPoint(target)
-	if err != nil && !os.IsNotExist(err) {
+	if err == nil && notMnt {
 		logrus.Warningf("NodeUnpublishVolume: %s is not mounted, err: %v", target, err)
-		return &csi.NodeUnpublishVolumeResponse{}, nil
-	}
-
-	if notMnt {
-		logrus.Infof("Volume %s has been unmounted already", req.GetVolumeId())
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 


### PR DESCRIPTION
This PR addresses the issue when filesystem gives IO error on doing a os.Stat() on the path.
In this case unmount was not being tried on the mountpoint even though the volume was mounted.
**dmesg:**
```
[44783.894404] print_req_error: I/O error, dev sdb, sector 5242752 flags 1801
[44783.901484] XFS (sdb): metadata I/O error in "xlog_iodone" at daddr 0x4fff80 len 64 error 5
[44783.909995] XFS (sdb): xfs_do_force_shutdown(0x2) called from line 1271 of file /build/linux-gcp-2nu89i/linux-gcp-5.0.0/fs/xfs/xfs_log.c. Return address = 0000000039615018
[44783.909997] XFS (sdb): Log I/O Error Detected. Shutting down filesystem
[44783.916775] XFS (sdb): Please unmount the filesystem and rectify the problem(s)
```
**kubectl describe po**
```
  Normal   Scheduled    8m6s                  default-scheduler                             Successfully assigned xfs/mongo-0 to gke-giri-default-pool-db2e9944-wm9z
  Warning  FailedMount  111s (x10 over 8m3s)  kubelet, gke-giri-default-pool-db2e9944-wm9z  MountVolume.MountDevice failed for volume "pvc-348d6de5-1cbd-11ea-859d-42010a800149" : stat /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-348d6de5-1cbd-11ea-859d-42010a800149/globalmount: input/output error
  Warning  FailedMount  90s (x3 over 6m3s)    kubelet, gke-giri-default-pool-db2e9944-wm9z  Unable to mount volumes for pod "mongo-0_xfs(61db3e1e-1cbf-11ea-859d-42010a800149)": timeout expired waiting for volumes to attach or mount for pod "xfs"/"mongo-0". list of unmounted volumes=[mongo-persistent-storage]. list of unattached volumes=[mongo-persistent-storage default-token-lsh8n]
```


Signed-off-by: Payes <payes.anand@mayadata.io>