### PR TITLE
feat(csi-metrics): add metrics support for volumes

### DIFF
--- a/pkg/service/v1alpha1/node_utils.go
+++ b/pkg/service/v1alpha1/node_utils.go
@@ -132,6 +132,7 @@ func newNodeCapabilities() []*csi.NodeServiceCapability {
 	for _, cap := range []csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	} {
 		capabilities = append(capabilities, fromType(cap))
 	}


### PR DESCRIPTION
Changes include CSI volume metrics support which can be pulled by promethues exporter to show the metrics in k8s cluster.

Currently to verify the metrics , node plugin logs can be checked.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>