### PR TITLE
feat(csi): get cstorvolume policy from the SC parameters

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -15,7 +15,7 @@
 #!/usr/bin/env bash
 
 OPENEBS_OPERATOR=https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
-CSPC_OPERATOR=https://raw.githubusercontent.com/openebs/openebs/master/k8s/cspc-operator.yaml
+CSPC_OPERATOR=https://raw.githubusercontent.com/openebs/openebs/master/k8s/cstor-operator.yaml
 CSI_OPERATOR="$GOPATH/src/github.com/openebs/cstor-csi/deploy/csi-operator.yaml"
 
 SRC_REPO="https://github.com/openebs/maya.git"

--- a/pkg/service/v1alpha1/controller.go
+++ b/pkg/service/v1alpha1/controller.go
@@ -95,6 +95,7 @@ func (cs *controller) CreateVolume(
 	size := req.GetCapacityRange().RequiredBytes
 	rCount := req.GetParameters()["replicaCount"]
 	cspcName := req.GetParameters()["cstorPoolCluster"]
+	policyName := req.GetParameters()["cstorVolumePolicy"]
 	VolumeContext := map[string]string{
 		"openebs.io/cas-type": req.GetParameters()["cas-type"],
 	}
@@ -117,7 +118,7 @@ func (cs *controller) CreateVolume(
 	if err == nil && cvc != nil && cvc.DeletionTimestamp == nil {
 		goto createVolumeResponse
 	}
-	err = utils.ProvisionVolume(size, volName, rCount, cspcName, snapshotID)
+	err = utils.ProvisionVolume(size, volName, rCount, cspcName, snapshotID, policyName)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -25,9 +25,9 @@ const (
 	gib100 int64 = gib * 100
 	tib    int64 = gib * 1024
 	tib100 int64 = tib * 100
-	// OpenebsConfigClass is the config class name passed to CSI from the
+	// OpenebsVolumePolicy is the config policy name passed to CSI from the
 	// storage class parameters
-	OpenebsConfigClass = "openebs.io/config-class"
+	OpenebsVolumePolicy = "openebs.io/volume-policy"
 	// OpenebsVolumeID is the PV name passed to CSI
 	OpenebsVolumeID = "openebs.io/volumeID"
 	// OpenebsCSPCName is the name of cstor storagepool cluster
@@ -49,11 +49,13 @@ func ProvisionVolume(
 	volName,
 	replicaCount,
 	cspcName,
-	snapshotID string,
+	snapshotID,
+	policyName string,
 ) error {
 
 	annotations := map[string]string{
-		OpenebsVolumeID: volName,
+		OpenebsVolumeID:     volName,
+		OpenebsVolumePolicy: policyName,
 	}
 
 	labels := map[string]string{


### PR DESCRIPTION
Changes gets the cstorvolumepolicy name from the storageclass
parameters and sets the annotations in Cstorvolumeclaim to get
it further used in configure cstorvolume target pods, etc

Example:
```yaml
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: cstor-sparse-auto
provisioner: cstor.csi.openebs.io
allowVolumeExpansion: true
parameters:
  replicaCount: "1"
  cstorPoolCluster: "cspc-sparse"
  cas-type: "cstor"
  cstorVolumePolicy: "csi-volume-policy"
```
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>