### PR TITLE
fix(csi, snapshot): enable status subresource in VolumeSnapshot CRD

### DIFF
--- a/deploy/csi-operator-ubuntu-18.04.yaml
+++ b/deploy/csi-operator-ubuntu-18.04.yaml
@@ -119,6 +119,8 @@ spec:
     kind: VolumeSnapshot
     plural: volumesnapshots
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
 
 ---
@@ -286,13 +288,13 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -119,6 +119,8 @@ spec:
     kind: VolumeSnapshot
     plural: volumesnapshots
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
 
 ---
@@ -286,13 +288,13 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/


### PR DESCRIPTION
with csi provisioner 1.4.0 changes volumesnapshot status has to be allowed to update the snapshot status, which is failing earlier due to missing status resource not exists.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>