### PR TITLE
Run rescan only for volume being resized

### DIFF
--- a/deploy/csi-operator-ubuntu-18.04.yaml
+++ b/deploy/csi-operator-ubuntu-18.04.yaml
@@ -1,6 +1,6 @@
 # This manifest deploys the OpenEBS CSI control plane components,
 # with associated CRs & RBAC rules. This manifest has been verified
-# only with Ubuntu 16.04 and CentOS hosts, due to dependencies on
+# only with Ubuntu 18.04 and Debian 10 hosts, due to dependencies on
 # kernel components of iSCSI protocol.  For other ubuntu flavours and
 # linux distros, this needs to be modified.
 #

--- a/pkg/iscsi/v1alpha1/iscsi_util.go
+++ b/pkg/iscsi/v1alpha1/iscsi_util.go
@@ -685,11 +685,11 @@ func (util *ISCSIUtil) UnmountDisk(
 }
 
 // ReScan rescans all the iSCSI sessions on the host
-func (util *ISCSIUtil) ReScan() error {
+func (util *ISCSIUtil) ReScan(iqn, targetPortal string) error {
 	b := &iscsiDiskMounter{
 		exec: mount.NewOsExec(),
 	}
-	out, err := b.exec.Run("iscsiadm", "-m", "session", "--rescan")
+	out, err := b.exec.Run("iscsiadm", "-m", "node", "-T", iqn, "-P", targetPortal, "--rescan")
 	if err != nil {
 		glog.Errorf("iscsi: rescan failed error: %s", string(out))
 		return err

--- a/pkg/iscsi/v1alpha1/mount.go
+++ b/pkg/iscsi/v1alpha1/mount.go
@@ -37,17 +37,17 @@ func Unmount(path string) error {
 
 // ResizeVolume rescans the iSCSI session and runs the resize to filesystem
 // command on that particular device
-func ResizeVolume(volumePath string, fsType string) error {
+func ResizeVolume(volumePath string, vol *apis.CSIVolume) error {
 	var err error
 	mounter := mount.New("")
 	list, _ := mounter.List()
 	for _, mpt := range list {
 		if mpt.Path == volumePath {
 			util := &ISCSIUtil{}
-			if err := util.ReScan(); err != nil {
+			if err := util.ReScan(vol.Spec.ISCSI.Iqn, vol.Spec.ISCSI.TargetPortal); err != nil {
 				return err
 			}
-			switch fsType {
+			switch vol.Spec.Volume.FSType {
 			case "ext4":
 				err = util.ResizeExt4(mpt.Device)
 			case "xfs":

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -355,7 +355,7 @@ func (ns *node) NodeExpandVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err = iscsiutils.ResizeVolume(req.GetVolumePath(), vol.Spec.Volume.FSType); err != nil {
+	if err = iscsiutils.ResizeVolume(req.GetVolumePath(), vol); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
 			"failed to handle NodeExpandVolumeRequest for %s, {%s}",


### PR DESCRIPTION
This PR addresses the issue of rescan commands getting stuck because of some stale iscsi sessions.
Initially, on receiving a resize filesystem command, rescan was being performed for all iSCSI sessions which will now be run only for volume being resized.
Signed-off-by: Payes <payes.anand@mayadata.io>