### PR TITLE
fix(topology): add customized topology key for node name

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -135,6 +135,11 @@ createVolumeResponse:
 			VolumeId:      volName,
 			CapacityBytes: size,
 			VolumeContext: VolumeContext,
+			AccessibleTopology: []*csi.Topology{
+				{
+					Segments: map[string]string{TopologyNodeKey: nodeID},
+				},
+			},
 			ContentSource: contentSource,
 		},
 	}, nil
@@ -323,11 +328,11 @@ func getAccessibilityRequirements(requirement *csi.TopologyRequirement) string {
 		return ""
 	}
 
-	preferredNode, exists := requirement.GetPreferred()[0].GetSegments()[HostTopologyKey]
+	preferredNode, exists := requirement.GetPreferred()[0].GetSegments()[TopologyNodeKey]
 	if exists {
 		return preferredNode
 	}
-	preferredNode, exists = requirement.GetRequisite()[0].GetSegments()[HostTopologyKey]
+	preferredNode, exists = requirement.GetRequisite()[0].GetSegments()[TopologyNodeKey]
 	if exists {
 		return preferredNode
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -135,11 +135,6 @@ createVolumeResponse:
 			VolumeId:      volName,
 			CapacityBytes: size,
 			VolumeContext: VolumeContext,
-			AccessibleTopology: []*csi.Topology{
-				{
-					Segments: map[string]string{TopologyNodeKey: nodeID},
-				},
-			},
 			ContentSource: contentSource,
 		},
 	}, nil

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -64,7 +64,7 @@ func (ns *node) NodeGetInfo(
 	req *csi.NodeGetInfoRequest,
 ) (*csi.NodeGetInfoResponse, error) {
 
-	topology := map[string]string{HostTopologyKey: ns.driver.config.NodeID}
+	topology := map[string]string{TopologyNodeKey: ns.driver.config.NodeID}
 	return &csi.NodeGetInfoResponse{
 		NodeId: ns.driver.config.NodeID,
 		AccessibleTopology: &csi.Topology{

--- a/pkg/driver/node_utils.go
+++ b/pkg/driver/node_utils.go
@@ -16,11 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	// HostTopologyKey is the supported topology key
-	HostTopologyKey string = "kubernetes.io/hostname"
-)
-
 func getTargetIP(url string) string {
 	s := strings.Split(url, ":")
 	//ip, port := s[0], s[1]

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -25,7 +25,7 @@ const (
 	defaultISCSIInterface = "default"
 
 	// TopologyNodeKey is a key of topology that represents node name.
-	TopologyNodeKey = "topology.cstor.openebs.io/node"
+	TopologyNodeKey = "topology.cstor.openebs.io/nodeName"
 )
 
 var (

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -23,6 +23,9 @@ const (
 
 	defaultISCSILUN       = int32(0)
 	defaultISCSIInterface = "default"
+
+	// TopologyNodeKey is a key of topology that represents node name.
+	TopologyNodeKey = "topology.cstor.openebs.io/node"
 )
 
 var (


### PR DESCRIPTION
This fix required in case if there is difference between actual nodeName and `kubernetes.io/hostname` label in k8s clusters . for example aws based k8s cluster have similar results

This difference causes plugin registration failed due to topology collision while updating Node object with CSI driver node info

for example in AWS based cluster
driver reported "kubernetes.io/hostname":"ip-192-168-45-94.ap-south-1.compute.internal"
but existing label is "kubernetes.io/hostname":"ip-192-168-45-94"

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>