### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 - docker
 language: go
 go:
-- 1.13.x
+- 1.12.9
 addons:
   apt:
     update: true
@@ -48,5 +48,5 @@ after_success:
 notifications:
   email:
     recipients:
-    - kiran.mova@openebs.io
-    - prateek.pandey@openebs.io
+    - kiran.mova@mayadata.io
+    - prateek.pandey@mayadata.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 - docker
 language: go
 go:
-- 1.12.9
+- 1.13.x
 addons:
   apt:
     update: true
@@ -49,3 +49,4 @@ notifications:
   email:
     recipients:
     - kiran.mova@openebs.io
+    - prateek.pandey@openebs.io

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This script builds the application from source for multiple platforms.
 set -e
 

--- a/buildscripts/cstor-csi-driver/Dockerfile
+++ b/buildscripts/cstor-csi-driver/Dockerfile
@@ -1,25 +1,39 @@
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
 #
-# This Dockerfile builds a recent volume-mgmt using the latest binary from
-# volume-mgmt  releases.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 FROM ubuntu:16.04
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog xfsprogs
 #RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 COPY cstor-csi-driver /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ARG BUILD_DATE
-LABEL org.label-schema.name="csi-driver"
-LABEL org.label-schema.description="OpenEBS"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-csi"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.name="cstor-csi-driver"
+LABEL org.label-schema.description="OpenEBS CStor CSI Driver"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/cstor-csi-driver"]
 EXPOSE 7676 7777

--- a/buildscripts/cstor-csi-driver/entrypoint.sh
+++ b/buildscripts/cstor-csi-driver/entrypoint.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -ex
 
 /usr/local/bin/csi-driver

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -55,9 +55,17 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
 
-  IMAGE_URI="${REPO}:${TAG}";
+  # Add an option to specify a custom TAG_SUFFIX
+  # via environment variable. Default is no tag.
+  # Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
+
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};
@@ -104,8 +112,7 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${DIMAGE} ];
@@ -65,6 +80,10 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
+    # Trim the `v` from the TRAVIS_TAG if it exists
+    # Example: v1.10.0 maps to 1.10.0
+    # Example: 1.10.0 maps to 1.10.0
+    # Example: v1.10.0-custom maps to 1.10.0-custom
     TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
@@ -85,7 +104,8 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
+    # Trim the `v` from the TRAVIS_TAG if it exists
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/buildscripts/test-cov.sh
+++ b/buildscripts/test-cov.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 echo "" > coverage.txt
 

--- a/buildscripts/test.sh
+++ b/buildscripts/test.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 # Create a temp dir and clean it up on exit

--- a/buildscripts/tools.go
+++ b/buildscripts/tools.go
@@ -1,7 +1,7 @@
 // +build tools
 
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020 The OpenEBS Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/buildscripts/travis-build.sh
+++ b/buildscripts/travis-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
-# Copyright 2017 The OpenEBS Authors.
+
+# Copyright 2020 The OpenEBS Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@ set -e
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -e
 
 SRC_REPO="$TRAVIS_BUILD_DIR"
 DST_REPO="$GOPATH/src/github.com/openebs/cstor-csi"


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
PR makes docker images configurable and removes the leading 'v' from image tags. This is required to make the image name consistent with other openebs images

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**: 
NA

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
