### PR TITLE
fix(CStorVolumeAttachment): Remove finalizer on unsuccesful mounts and on driver restarts

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -173,8 +173,8 @@ func (ns *node) NodeStageVolume(
 			vol.Finalizers = nil
 			// There might still be a case that the attach was successful,
 			// therefore not cleaning up the staging path from CR
-			if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
-				return nil, status.Error(codes.Internal, err.Error())
+			if _, uerr := utils.UpdateCStorVolumeAttachmentCR(vol); uerr != nil {
+				logrus.Errorf("Failed to update CStorVolumeAttachment:%v", uerr.Error())
 			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -132,7 +132,7 @@ func (ns *node) NodeStageVolume(
 			"/dev/disk/by-path/ip", vol.Spec.ISCSI.TargetPortal,
 			"iscsi", vol.Spec.ISCSI.Iqn, "lun", fmt.Sprint(0)}, "-",
 		)
-		err = utils.UpdateCStorVolumeAttachmentCR(vol)
+		vol, err = utils.UpdateCStorVolumeAttachmentCR(vol)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -151,8 +151,8 @@ func (ns *node) NodeStageVolume(
 			vol.Finalizers = nil
 			// There might still be a case that the attach was successful,
 			// therefore not cleaning up the staging path from CR
-			if err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
-				return nil, status.Error(codes.Internal, err.Error())
+			if _, err1 := utils.UpdateCStorVolumeAttachmentCR(vol); err1 != nil {
+				return nil, status.Error(codes.Internal, err1.Error())
 			}
 			logrus.Errorf("NodeStageVolume: failed to attachDisk for volume %v, err: %v", volumeID, err)
 			return nil, status.Error(codes.Internal, err.Error())
@@ -173,7 +173,7 @@ func (ns *node) NodeStageVolume(
 			vol.Finalizers = nil
 			// There might still be a case that the attach was successful,
 			// therefore not cleaning up the staging path from CR
-			if err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
+			if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
 				return nil, status.Error(codes.Internal, err.Error())
 			}
 			return nil, status.Error(codes.Internal, err.Error())
@@ -249,7 +249,7 @@ func (ns *node) NodeUnstageVolume(
 
 	vol.Finalizers = nil
 	vol.Spec.Volume.StagingTargetPath = ""
-	if err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
+	if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	logrus.Infof("hostpath: volume %s path: %s has been unmounted.",
@@ -283,7 +283,7 @@ func (ns *node) NodePublishVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	vol.Spec.Volume.TargetPath = req.GetTargetPath()
-	if err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
+	if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -329,7 +329,7 @@ func (ns *node) NodeUnpublishVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	vol.Spec.Volume.TargetPath = ""
-	if err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
+	if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/driver/service.go
+++ b/pkg/driver/service.go
@@ -87,6 +87,7 @@ func New(config *config.Config) *CSIDriver {
 		driver.cs = NewController(driver)
 
 	case "node":
+		utils.CleanupOnRestart()
 		// Start monitor goroutine to monitor the
 		// mounted paths. If a path goes down or
 		// becomes read only (in case of RW mount

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -134,11 +134,10 @@ func CreateCStorVolumeAttachmentCR(csivol *apis.CStorVolumeAttachment, nodeID st
 }
 
 // UpdateCStorVolumeAttachmentCR updates CStorVolumeAttachment CR related to current nodeID
-func UpdateCStorVolumeAttachmentCR(csivol *apis.CStorVolumeAttachment) error {
+func UpdateCStorVolumeAttachmentCR(csivol *apis.CStorVolumeAttachment) (*apis.CStorVolumeAttachment, error) {
 
-	_, err := csivolume.NewKubeclient().
+	return csivolume.NewKubeclient().
 		WithNamespace(OpenEBSNamespace).Update(csivol)
-	return err
 }
 
 // TODO Explain when a create of csi volume happens & when it

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -319,6 +319,8 @@ func CleanupOnRestart() {
 		}
 		vol := Vol
 		TransitionVolList[vol.Spec.Volume.Name] = apis.CStorVolumeAttachmentStatusUnmountUnderProgress
+		// This is being run in a go routine so that if unmount and detach
+		// commands take time, the startup is not delayed
 		go func(vol *apis.CStorVolumeAttachment) {
 			if err := iscsiutils.UnmountAndDetachDisk(vol, vol.Spec.Volume.StagingTargetPath); err == nil {
 				vol.Finalizers = nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -322,7 +322,7 @@ func CleanupOnRestart() {
 		go func(vol *apis.CStorVolumeAttachment) {
 			if err := iscsiutils.UnmountAndDetachDisk(vol, vol.Spec.Volume.StagingTargetPath); err == nil {
 				vol.Finalizers = nil
-				if err = UpdateCStorVolumeAttachmentCR(vol); err != nil {
+				if vol, err = UpdateCStorVolumeAttachmentCR(vol); err != nil {
 					logrus.Errorf(err.Error())
 				}
 			} else {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Finalizer can be left on CStorVolumeAttachment CR in the following cases:
1. Unsuccessful attach/mount 
2. NodeRestarts
3. Driver crashes after unmounting the volume.
In the above cases the volume is not mounted due to which, kubelet doesn't send a Unstage request.

**What this PR does**:
This PR implements the following to address these issues:
1. Remove finalizer if the volume attach/mount fails
2. Unmount/Detach volumes and remove finalizer if DeletionTimestamp is set on corresponding CStorVolumeAttachment CR on driver restarts.