### PR TITLE
fix(VERSION): remove version dependency during volume provisioning

### DIFF
--- a/pkg/utils/maya.go
+++ b/pkg/utils/maya.go
@@ -12,7 +12,6 @@ import (
 	csivol "github.com/openebs/cstor-csi/pkg/cstor/volumeattachment"
 	cvc "github.com/openebs/cstor-csi/pkg/cstor/volumeconfig"
 	pvc "github.com/openebs/cstor-csi/pkg/kubernetes/persistentvolumeclaim"
-	"github.com/openebs/cstor-csi/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -107,7 +106,6 @@ func ProvisionVolume(
 		WithNodeID(nodeID).
 		WithReplicaCount(replicaCount).
 		WithProvisionCapacityQty(sSize).
-		WithNewVersion(version.Current()).
 		WithDependentsUpgraded().
 		WithStatusPhase(cstorapis.CStorVolumeConfigPhasePending).Build()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR does the following changes
- Removes the dependency with CVC Version during volume
  provisioning.
- Updates the VERSION variable with ${CURRENT_BRANCH_NAME}-dev
  during build time

**Why we need this PR**:
This PR is required to break the dependency with CVC-Operator
during volume provisioning. Below are the existing steps performed
during volume provisioning:
- CSI driver receives volume create requests and creates CVC with VERSION details
- CVC controller will reconcile for CVCs only if `cvc.VersionDetails.Status.Current`
   matches to VERSION value in CVC controller. If reconciliation doesn't happen then
   CStorVolume resources will not create hence the application will not get OpenEBS volume.


**Which issue(s) this PR fixes**:
Fixes # https://github.com/openebs/cstor-operators/issues/108


**Special notes for your reviewer**:
- This PR is continuation of PR #94 
**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
