### PR TITLE
refact(operator): mount host root partition inside container

### DIFF
--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -727,7 +727,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cstor-csi-plugin
-          image: quay.io/openebs/cstor-csi-driver:ci
+          image: openebs/cstor-csi-driver:ci
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -735,9 +735,9 @@ spec:
             - name: OPENEBS_CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: OPENEBS_CSI_API_URL
-              value: https://api.openebs.com/
-            - name: OPENEBS_MAPI_SVC
-              value: maya-apiserver-service
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
             - name: OPENEBS_NAMESPACE
               value: openebs
           args :
@@ -861,6 +861,28 @@ roleRef:
 
 ---
 
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-iscsiadm
+  namespace: kube-system
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+
+---
+
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -924,7 +946,7 @@ spec:
             capabilities:
               add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/openebs/cstor-csi-driver:ci
+          image: openebs/cstor-csi-driver:ci
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"
@@ -940,12 +962,14 @@ spec:
               value: unix:///plugin/csi.sock
             - name: OPENEBS_NODE_DRIVER
               value: node
-            - name: OPENEBS_API_URL
-              value: https://api.openebs.com/
-            - name: OPENEBS_MAPI_SVC
-              value: maya-apiserver-service
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
             - name: OPENEBS_NAMESPACE
               value: openebs
+              # Enable/Disable auto-remount feature, when volumes
+              # recovers form the read-only state
             - name: REMOUNT
               value: "false"
           volumeMounts:
@@ -958,8 +982,11 @@ spec:
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
-            - name: iscsiadm-bin
+            - name: host-root
+              mountPath: /host
+            - name: chroot-iscsiadm
               mountPath: /sbin/iscsiadm
+              subPath: iscsiadm
       volumes:
         - name: device-dir
           hostPath:
@@ -977,7 +1004,11 @@ spec:
           hostPath:
             path: /var/lib/kubelet/
             type: Directory
-        - name: iscsiadm-bin
+        - name: chroot-iscsiadm
+          configMap:
+            defaultMode: 0755
+            name: openebs-cstor-csi-iscsiadm
+        - name: host-root
           hostPath:
-            path: /sbin/iscsiadm
-            type: File
+            path: /
+            type: Directory

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -252,7 +252,7 @@ func (ns *node) NodeUnstageVolume(
 	if _, err = utils.UpdateCStorVolumeAttachmentCR(vol); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	logrus.Infof("hostpath: volume %s path: %s has been unmounted.",
+	logrus.Infof("cstor-csi: volume %s path: %s has been unmounted.",
 		volumeID, stagingTargetPath)
 
 	return &csi.NodeUnstageVolumeResponse{}, nil


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Mount `/` partition under `/host` directory inside the container
and use chroot to run iscsiadm under `/host` directory so that
it can find all necessary shared libraies it depends on.

For more info refer: https://github.com/openebs/cstor-operators/pull/119

Also handles the dual mount paths exists due to root reference mount

```sh
mount | grep pvc
/dev/sdd on /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-42d5a9a5-4403-44a3-a962-ad0162a0fa8d/globalmount type ext4 (rw,relatime,stripe=256)
/dev/sdd on /host/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-42d5a9a5-4403-44a3-a962-ad0162a0fa8d/globalmount type ext4 (rw,relatime,stripe=256)
```

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
