### PR TITLE
refact(cvc): add pvc annotation during provisioning

### DIFF
--- a/pkg/cstor/volumeconfig/build.go
+++ b/pkg/cstor/volumeconfig/build.go
@@ -353,7 +353,7 @@ func (b *Builder) WithNodeID(nodeID string) *Builder {
 		b.errs = append(
 			b.errs,
 			errors.New(
-				"failed to build cstorvolumeclaim object: missing nodeID",
+				"failed to build cstorvolumeconfig object: missing nodeID",
 			),
 		)
 		return b

--- a/pkg/utils/maya.go
+++ b/pkg/utils/maya.go
@@ -28,6 +28,9 @@ const (
 	// OpenebsVolumePolicy is the config policy name passed to CSI from the
 	// storage class parameters
 	OpenebsVolumePolicy = "openebs.io/volume-policy"
+	// OpenebsPVC is the name of persistentvolumeclaim passed to CSI form the
+	// Storage class parameters
+	OpenebsPVC = "openebs.io/persistent-volume-claim"
 	// OpenebsVolumeID is the PV name passed to CSI
 	OpenebsVolumeID = "openebs.io/volumeID"
 	// OpenebsCSPCName is the name of cstor storagepool cluster
@@ -67,6 +70,7 @@ func ProvisionVolume(
 	annotations := map[string]string{
 		OpenebsVolumeID:     volName,
 		OpenebsVolumePolicy: policyName,
+		OpenebsPVC:          pvcName,
 	}
 
 	if pvcName != "" {


### PR DESCRIPTION
commit add the persistentvolumeclaim name annotation
in CVC resource while provisioning, requires to set
in volume target deployments

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>
(cherry picked from commit 79932da41bd5e5d5fe186ab71c8f7515067d9fcb)

