### PR TITLE
fix(NodeUnstage): avoid stale iscsi sessions

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -194,9 +194,9 @@ func (ns *node) NodeUnstageVolume(
 	req *csi.NodeUnstageVolumeRequest,
 ) (*csi.NodeUnstageVolumeResponse, error) {
 	var (
-		err             error
-		vol             *apis.CStorVolumeAttachment
-		unmountRequired bool
+		err error
+		vol *apis.CStorVolumeAttachment
+		//unmountRequired bool
 	)
 
 	if err = ns.validateNodeUnStageReq(req); err != nil {
@@ -219,31 +219,30 @@ func (ns *node) NodeUnstageVolume(
 		return &csi.NodeUnstageVolumeResponse{}, nil
 
 	}
-	unmountRequired, err = IsUnmountRequired(volumeID, stagingTargetPath)
-	if err != nil {
+	//	unmountRequired, err = IsUnmountRequired(volumeID, stagingTargetPath)
+	//if err != nil {
+	//return nil, status.Error(codes.Internal, err.Error())
+	//	}
+	//if unmountRequired {
+	// if node driver restarts before this step Kubelet will trigger the
+	// NodeUnpublish command again so there is no need to worry that when this
+	// driver restarts it will pick up the CStorVolumeAttachment CR and start monitoring
+	// mount point again.
+	// If the node is down for some time, other node driver will first delete
+	// this node's CStorVolumeAttachment CR and then only will start its mount process.
+	// If there is a case that this node comes up and CStorVolumeAttachment CR is picked and
+	// this node starts monitoring the mount point while the other node is also
+	// trying to mount which appears to be a race condition but is not since
+	// first of  all this CR will be marked for deletion when the other node
+	// starts mounting. But lets say this node started monitoring and
+	// immediately other node deleted this node's CR, in that case iSCSI
+	// target(istgt) will pick up the new one and allow only that node to login,
+	// so all the cases are handled
+	utils.TransitionVolList[volumeID] = apis.CStorVolumeAttachmentStatusUnmountUnderProgress
+	if err = iscsiutils.UnmountAndDetachDisk(vol, stagingTargetPath); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if unmountRequired {
-		// if node driver restarts before this step Kubelet will trigger the
-		// NodeUnpublish command again so there is no need to worry that when this
-		// driver restarts it will pick up the CStorVolumeAttachment CR and start monitoring
-		// mount point again.
-		// If the node is down for some time, other node driver will first delete
-		// this node's CStorVolumeAttachment CR and then only will start its mount process.
-		// If there is a case that this node comes up and CStorVolumeAttachment CR is picked and
-		// this node starts monitoring the mount point while the other node is also
-		// trying to mount which appears to be a race condition but is not since
-		// first of  all this CR will be marked for deletion when the other node
-		// starts mounting. But lets say this node started monitoring and
-		// immediately other node deleted this node's CR, in that case iSCSI
-		// target(istgt) will pick up the new one and allow only that node to login,
-		// so all the cases are handled
-		utils.TransitionVolList[volumeID] = apis.CStorVolumeAttachmentStatusUnmountUnderProgress
-		if err = iscsiutils.UnmountAndDetachDisk(vol, stagingTargetPath); err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		utils.TransitionVolList[volumeID] = apis.CStorVolumeAttachmentStatusUnmounted
-	}
+	utils.TransitionVolList[volumeID] = apis.CStorVolumeAttachmentStatusUnmounted
 	// It is safe to delete the CStorVolumeAttachment CR now since the volume has already
 	// been unmounted and logged out
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -196,7 +196,6 @@ func (ns *node) NodeUnstageVolume(
 	var (
 		err error
 		vol *apis.CStorVolumeAttachment
-		//unmountRequired bool
 	)
 
 	if err = ns.validateNodeUnStageReq(req); err != nil {
@@ -217,13 +216,7 @@ func (ns *node) NodeUnstageVolume(
 	}
 	if vol.Spec.Volume.StagingTargetPath == "" {
 		return &csi.NodeUnstageVolumeResponse{}, nil
-
 	}
-	//	unmountRequired, err = IsUnmountRequired(volumeID, stagingTargetPath)
-	//if err != nil {
-	//return nil, status.Error(codes.Internal, err.Error())
-	//	}
-	//if unmountRequired {
 	// if node driver restarts before this step Kubelet will trigger the
 	// NodeUnpublish command again so there is no need to worry that when this
 	// driver restarts it will pick up the CStorVolumeAttachment CR and start monitoring

--- a/pkg/utils/server.go
+++ b/pkg/utils/server.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"sync"
 
-	"github.com/golang/glog"
 	"google.golang.org/grpc"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
 )
 
 // TD: @amitd
@@ -89,7 +89,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 
 	proto, addr, err := parseEndpoint(endpoint)
 	if err != nil {
-		glog.Fatal(err.Error())
+		logrus.Fatal(err.Error())
 	}
 
 	// Clear off the addr if it is already present, this is done to remove stale
@@ -99,13 +99,13 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	if proto == "unix" {
 		addr = "/" + addr
 		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
-			glog.Fatalf("Failed to remove %s, error: %s", addr, err.Error())
+			logrus.Fatalf("Failed to remove %s, error: %s", addr, err.Error())
 		}
 	}
 
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
-		glog.Fatalf("Failed to listen: %v", err)
+		logrus.Fatalf("Failed to listen: %v", err)
 	}
 
 	opts := []grpc.ServerOption{
@@ -126,7 +126,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		csi.RegisterNodeServer(server, ns)
 	}
 
-	glog.Infof("Listening for connections on address: %#v", listener.Addr())
+	logrus.Infof("Listening for connections on address: %#v", listener.Addr())
 
 	// Start serving requests on the grpc server created
 	server.Serve(listener)


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
- Handle the mount reference count due to root mount inside the node daemonset container.
  iSCSI logout was being avoided due to Multiple references to staging path causes the stale iscsi sessions.
- iSCSI stale session in case node-plugin get restarted in between
- Added error checks to handle the iscsi errors  in retry cases
- Fix the iscsi logs


**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
