### PR TITLE
fix(create): validate create volume request access mode

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -18,9 +18,7 @@
 NDM_OPERATOR=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/ndm-operator.yaml
 CSTOR_RBAC=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/rbac.yaml
 CSTOR_OPERATOR=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/cstor-operator.yaml
-VOL_CRD=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/volumes-crd.yaml
-CSPC_CRD=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/cspc-crd.yaml
-CSPI_CRD=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/cspi-crd.yaml
+ALL_CRD=https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/all_cstor_crds.yaml
 
 CSI_OPERATOR="$GOPATH/src/github.com/openebs/cstor-csi/deploy/csi-operator.yaml"
 SNAPSHOT_CLASS="$GOPATH/src/github.com/openebs/cstor-csi/deploy/snapshot-class.yaml"
@@ -31,9 +29,7 @@ DST_PATH="$GOPATH/src/github.com/openebs"
 # Minikube is already running
 kubectl apply -f $CSTOR_RBAC
 kubectl apply -f $NDM_OPERATOR
-kubectl apply -f $VOL_CRD
-kubectl apply -f $CSPC_CRD
-kubectl apply -f $CSPI_CRD
+kubectl apply -f $ALL_CRD
 kubectl apply -f $CSTOR_OPERATOR
 kubectl apply -f $CSI_OPERATOR
 kubectl apply -f $SNAPSHOT_CLASS

--- a/pkg/driver/controller_utils.go
+++ b/pkg/driver/controller_utils.go
@@ -150,6 +150,13 @@ func (cs *controller) validateVolumeCreateReq(req *csi.CreateVolumeRequest) erro
 				)
 			}
 		}
+		if mode := volcap.GetAccessMode(); mode != nil {
+			modeName := csi.VolumeCapability_AccessMode_Mode_name[int32(mode.GetMode())]
+			// we only support SINGLE_NODE_WRITER
+			if mode.GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+				return status.Errorf(codes.InvalidArgument, "unsupported access mode: %s", modeName)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/driver/controller_utils.go
+++ b/pkg/driver/controller_utils.go
@@ -154,7 +154,10 @@ func (cs *controller) validateVolumeCreateReq(req *csi.CreateVolumeRequest) erro
 			modeName := csi.VolumeCapability_AccessMode_Mode_name[int32(mode.GetMode())]
 			// we only support SINGLE_NODE_WRITER
 			if mode.GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
-				return status.Errorf(codes.InvalidArgument, "unsupported access mode: %s", modeName)
+				return status.Errorf(codes.InvalidArgument,
+					"only SINGLE_NODE_WRITER supported, unsupported access mode requested: %s",
+					modeName,
+				)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Commits adds the validation to validate the create volume request access mode and support only single node writer
i.e. `ReadWriteOnce` accessmode and failed for other unsupported modes, like `ReadWriteMany`

- Tested the changes using a `ReadWriteMany` accessmode PVC and verify the error.

```yaml

kubectl describe pvc
Name:          claim-csi-123
Namespace:     default
StorageClass:  cstor-sparse-auto
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   volume.beta.kubernetes.io/storage-provisioner: cstor.csi.openebs.io
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type     Reason                Age                   From                                                                                      Message
  ----     ------                ----                  ----                                                                                      -------
  Normal   ExternalProvisioning  3m38s (x62 over 18m)  persistentvolume-controller                                                               waiting for a volume to be created, either by external provisioner "cstor.csi.openebs.io" or manually created by system administrator
  Normal   Provisioning          17s (x12 over 18m)    cstor.csi.openebs.io_openebs-cstor-csi-controller-0_e3f45483-77c5-45e5-bb1a-ee9abc85a70b  External provisioner is provisioning volume for claim "default/claim-csi-123"
  Warning  ProvisioningFailed    17s (x12 over 18m)    cstor.csi.openebs.io_openebs-cstor-csi-controller-0_e3f45483-77c5-45e5-bb1a-ee9abc85a70b  failed to provision volume with StorageClass "cstor-sparse-auto": rpc error: code = InvalidArgument desc = unsupported access mode: MULTI_NODE_MULTI_WRITER


```

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
