### PR TITLE
cherry-pick(remount-fix): resolve race condition in remount code

### DIFF
--- a/pkg/apis/cstor/v1/csivolume.go
+++ b/pkg/apis/cstor/v1/csivolume.go
@@ -156,6 +156,8 @@ const (
 	// CStorVolumeAttachmentStatusWaitingForVolumeToBeReady indicates that the replicas are
 	// yet to connect to target
 	CStorVolumeAttachmentStatusWaitingForVolumeToBeReady CStorVolumeAttachmentStatus = "WaitingForVolumeToBeReady"
+	// CStorVolumeAttachmentStatusRemountUnderProgress indicates that the volume is being remounted
+	CStorVolumeAttachmentStatusRemountUnderProgress CStorVolumeAttachmentStatus = "RemountUnderProgress"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -251,6 +251,10 @@ func MonitorMounts() {
 				break
 			}
 			for _, vol := range csivolList.Items {
+				// ignore monitoring for volumes with deletion timestamp set
+				if vol.DeletionTimestamp != nil {
+					continue
+				}
 				// ignore monitoring the mount for a block device
 				if vol.Spec.Volume.AccessType == "block" {
 					continue
@@ -280,19 +284,19 @@ func MonitorMounts() {
 					continue
 				}
 				if _, ok := TransitionVolList[vol.Spec.Volume.Name]; !ok {
-					TransitionVolList[vol.Spec.Volume.Name] = vol.Status
-					ReqMountList[vol.Spec.Volume.Name] = vol.Status
 					csivol := vol
-					go func() {
+					TransitionVolList[csivol.Spec.Volume.Name] = apis.CStorVolumeAttachmentStatusRemountUnderProgress
+					ReqMountList[csivol.Spec.Volume.Name] = apis.CStorVolumeAttachmentStatusRemountUnderProgress
+					go func(csivol apis.CStorVolumeAttachment) {
 						logrus.Infof("Remounting vol: %s at %s and %s",
-							vol.Spec.Volume.Name, vol.Spec.Volume.StagingTargetPath,
-							vol.Spec.Volume.TargetPath)
+							csivol.Spec.Volume.Name, csivol.Spec.Volume.StagingTargetPath,
+							csivol.Spec.Volume.TargetPath)
 						defer func() {
 							TransitionVolListLock.Lock()
 							// Remove the volume from ReqMountList once the remount operation is
 							// complete
-							delete(TransitionVolList, vol.Spec.Volume.Name)
-							delete(ReqMountList, vol.Spec.Volume.Name)
+							delete(TransitionVolList, csivol.Spec.Volume.Name)
+							delete(ReqMountList, csivol.Spec.Volume.Name)
 							TransitionVolListLock.Unlock()
 						}()
 						if err := RemountVolume(
@@ -301,15 +305,15 @@ func MonitorMounts() {
 						); err != nil {
 							logrus.Errorf(
 								"Remount failed for vol: %s : err: %v",
-								vol.Spec.Volume.Name, err,
+								csivol.Spec.Volume.Name, err,
 							)
 						} else {
 							logrus.Infof(
 								"Remount successful for vol: %s",
-								vol.Spec.Volume.Name,
+								csivol.Spec.Volume.Name,
 							)
 						}
-					}()
+					}(csivol)
 				}
 			}
 			TransitionVolListLock.Unlock()


### PR DESCRIPTION
When the remount feature is enabled process will be monitoring for mount points on that node. If mount points are marked as RO, process will launch go routines for them in a loop. Since these go routine are using the same stack variable vol when the loop iterates, change in value of the variable will lead to volumes not getting removed from transition list.

Signed-off-by: Payes Anand <payes.anand@mayadata.io>