### PR TITLE
cherry-pick(remount-fix): resolve race condition in remount code

### DIFF
--- a/pkg/apis/cstor/v1/csivolume.go
+++ b/pkg/apis/cstor/v1/csivolume.go
@@ -156,6 +156,8 @@ const (
 	// CStorVolumeAttachmentStatusWaitingForVolumeToBeReady indicates that the replicas are
 	// yet to connect to target
 	CStorVolumeAttachmentStatusWaitingForVolumeToBeReady CStorVolumeAttachmentStatus = "WaitingForVolumeToBeReady"
+	// CStorVolumeAttachmentStatusRemountUnderProgress indicates that the volume is being remounted
+	CStorVolumeAttachmentStatusRemountUnderProgress CStorVolumeAttachmentStatus = "RemountUnderProgress"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
When the remount feature is enabled process will be monitoring for mount points on that node. If mount points are marked as RO, process will launch go routines for them in a loop. Since these go routine are using the same stack variable vol when the loop iterates, change in value of the variable will lead to volumes not getting removed from transition list.

Signed-off-by: Payes Anand <payes.anand@mayadata.io>