### PR TITLE
refact(build): run only amd64 and arm64 builds

### DIFF
--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -22,7 +22,8 @@ endif
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
+	#export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -54,6 +54,8 @@ then
   exit 1
 fi
 
+DIMAGE="${DIMAGE}-${XC_ARCH}"
+
 # Generate a unique tag based on the commit and tag
 BUILD_ID=$(git describe --tags --always)
 


### PR DESCRIPTION
Enabling more than two arch in the multi-arch builds
is resulting in increased build times as well as
intermittent failures in running the builds.
    
Limiting to two archs - amd64 and arm64 for now.

Ran the actions with various combinations:

Observations:

2 arches complete within 10 mins and all 3 runs tried were successful. 
3 arches take about 30 mins - 1 in 3 builds passed
4 arches take about 30+ mins, 1 in 5 builds passed

Signed-off-by: kmova <kiran.mova@mayadata.io>


