### PR TITLE
chore(build): propogate envs to buildkit container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set tag
+      - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ export XC_ARCH
 ARCH:=${XC_OS}_${XC_ARCH}
 export ARCH
 
-export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg BRANCH=${BRANCH} --build-arg RELEASE_TAG=${RELEASE_TAG}
 
 
 # Specify the name for the binary

--- a/buildscripts/cstor-csi-driver/cstor-csi-driver.Dockerfile
+++ b/buildscripts/cstor-csi-driver/cstor-csi-driver.Dockerfile
@@ -14,6 +14,8 @@
 
 FROM golang:1.14.7 as build
 
+ARG BRANCH
+ARG RELEASE_TAG
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT=""
@@ -23,7 +25,9 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  BRANCH=${BRANCH} \
+  RELEASE_TAG=${RELEASE_TAG}
 
 WORKDIR /go/src/github.com/openebs/cstor-csi/
 


### PR DESCRIPTION
**What this PR does**:
- pass RELEASE_TAG and BRANCH as build args to buildkit container
- replace deprecated methods in github actions

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
