### PR TITLE
fix(action): add missing ginkgo dependencies in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Build images locally
         run: make csi-driver-image || exit 1;
 
-      - name: Install ginkgo
-        run: go get github.com/onsi/ginkgo/ginkgo && go get github.com/onsi/gomega/...
+      - name: Install tests dependencies
+        run: make bootstrap
 
       - name: Running tests
         run: ./ci/ci-test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build images locally
         run: make csi-driver-image || exit 1;
 
-      - name: Install ginkgo
-        run: go get github.com/onsi/ginkgo/ginkgo && go get github.com/onsi/gomega/...
+      - name: Install tests dependencies
+        run: make bootstrap
 
       - name: Running tests
         run: ./ci/ci-test.sh

--- a/tests/e2e/run_test.go
+++ b/tests/e2e/run_test.go
@@ -197,7 +197,7 @@ func verifyCVDeleted(cvName string) {
 			return fmt.Errorf("cstorvolume exists %s", cvName)
 		}
 		return nil
-	}).Should(Succeed())
+	}, 300, 10).Should(Succeed())
 }
 
 func verifySnapshotDeleted(snapName string) {


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

**What this PR does**:
 add/install the ginko dependencies in build and release github action workflows ( build and release), which was missed to add as part of earlier changes. 
https://github.com/openebs/cstor-csi/blob/13a0d2316ded0e96a517940a366db3440914b2a8/.github/workflows/pull_request.yml#L89

