### PR TITLE
fix(cleanup): add cleanup of volumes from node  to monitor func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -213,7 +213,7 @@ func (ns *node) NodeStageVolume(
 			// There might still be a case that the attach was successful,
 			// therefore not cleaning up the staging path from CR
 			if _, uerr := utils.UpdateCStorVolumeAttachmentCR(vol); uerr != nil {
-				logrus.Errorf("Failed to update CStorVolumeAttachment for %s: %v", volumeID, uerr.Error())
+				logrus.Errorf("Failed to update cva for %s: %v", volumeID, uerr.Error())
 			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -252,6 +252,7 @@ func (ns *node) NodeUnstageVolume(
 
 	if vol, err = utils.GetCStorVolumeAttachment(volumeID + "-" + utils.NodeIDENV); err != nil {
 		if k8serror.IsNotFound(err) {
+			logrus.Infof("cva for %s has already been deleted", volumeID)
 			return &csi.NodeUnstageVolumeResponse{}, nil
 		}
 		return nil, status.Error(codes.Internal, err.Error())
@@ -365,6 +366,7 @@ func (ns *node) NodeUnpublishVolume(
 	vol, err := utils.GetCStorVolumeAttachment(volumeID + "-" + utils.NodeIDENV)
 	if err != nil {
 		if k8serror.IsNotFound(err) {
+			logrus.Infof("cva for %s has already been deleted", volumeID)
 			return &csi.NodeUnpublishVolumeResponse{}, nil
 		}
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -206,13 +207,13 @@ func (ns *node) NodeStageVolume(
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 
-		logrus.Info("NodeStageVolume: start format and mount operation")
+		logrus.Infof("NodeStageVolume %v: start format and mount operation", volumeID)
 		if err := ns.formatAndMount(req, devicePath); err != nil {
 			vol.Finalizers = nil
 			// There might still be a case that the attach was successful,
 			// therefore not cleaning up the staging path from CR
 			if _, uerr := utils.UpdateCStorVolumeAttachmentCR(vol); uerr != nil {
-				logrus.Errorf("Failed to update CStorVolumeAttachment:%v", uerr.Error())
+				logrus.Errorf("Failed to update CStorVolumeAttachment for %s: %v", volumeID, uerr.Error())
 			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -250,8 +251,12 @@ func (ns *node) NodeUnstageVolume(
 	defer removeVolumeFromTransitionList(volumeID)
 
 	if vol, err = utils.GetCStorVolumeAttachment(volumeID + "-" + utils.NodeIDENV); err != nil {
+		if k8serror.IsNotFound(err) {
+			return &csi.NodeUnstageVolumeResponse{}, nil
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+
 	if vol.Spec.Volume.StagingTargetPath == "" {
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
@@ -359,6 +364,9 @@ func (ns *node) NodeUnpublishVolume(
 	}
 	vol, err := utils.GetCStorVolumeAttachment(volumeID + "-" + utils.NodeIDENV)
 	if err != nil {
+		if k8serror.IsNotFound(err) {
+			return &csi.NodeUnpublishVolumeResponse{}, nil
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	vol.Spec.Volume.TargetPath = ""

--- a/pkg/driver/node_utils.go
+++ b/pkg/driver/node_utils.go
@@ -323,10 +323,6 @@ func (ns *node) prepareVolumeForNode(
 	volumeID := req.GetVolumeId()
 	nodeID := ns.driver.config.NodeID
 
-	if err := utils.PatchCVCNodeID(volumeID, nodeID); err != nil {
-		return err
-	}
-
 	labels := map[string]string{
 		"nodeID":  nodeID,
 		"Volname": volumeID,
@@ -356,7 +352,7 @@ func (ns *node) prepareVolumeForNode(
 	} else if !isCVCBound {
 		utils.TransitionVolList[volumeID] = apis.CStorVolumeAttachmentStatusWaitingForCVCBound
 		time.Sleep(10 * time.Second)
-		return errors.New("Waiting for CVC to be bound")
+		return errors.Errorf("Waiting for %s's CVC to be bound", volumeID)
 	}
 
 	if err = utils.FetchAndUpdateISCSIDetails(volumeID, vol); err != nil {
@@ -368,7 +364,7 @@ func (ns *node) prepareVolumeForNode(
 		return err
 	} else if err == nil && oldvol != nil {
 		if oldvol.DeletionTimestamp != nil {
-			return errors.Errorf("Volume still mounted on node: %s", nodeID)
+			return errors.Errorf("Volume %s still mounted on node: %s", volumeID, nodeID)
 		}
 		return nil
 	}

--- a/pkg/driver/service.go
+++ b/pkg/driver/service.go
@@ -87,7 +87,9 @@ func New(config *config.Config) *CSIDriver {
 		driver.cs = NewController(driver)
 
 	case "node":
-		utils.CleanupOnRestart()
+		if err := utils.Cleanup(); err != nil {
+			logrus.Fatalf(err.Error())
+		}
 		// Start monitor goroutine to monitor the
 		// mounted paths. If a path goes down or
 		// becomes read only (in case of RW mount

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -95,8 +95,8 @@ func addVolumeToTransitionList(volumeID string, status apis.CStorVolumeAttachmen
 	defer utils.TransitionVolListLock.Unlock()
 
 	if _, ok := utils.TransitionVolList[volumeID]; ok {
-		return fmt.Errorf("Volume Busy, status: %v",
-			utils.TransitionVolList[volumeID])
+		return fmt.Errorf("Volume %s Busy, status: %v",
+			volumeID, utils.TransitionVolList[volumeID])
 	}
 	utils.TransitionVolList[volumeID] = status
 	return nil

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -21,6 +21,7 @@ import (
 	node "github.com/openebs/cstor-csi/pkg/kubernetes/node"
 	pv "github.com/openebs/cstor-csi/pkg/kubernetes/persistentvolume"
 	errors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -151,6 +152,7 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
 	}
 
 	for _, csivol := range csivols.Items {
+		logrus.Infof("Marking cva %s for deletion", csivol.Name)
 		err = csivolume.NewKubeclient().
 			WithNamespace(OpenEBSNamespace).Delete(csivol.Name)
 		if err != nil {
@@ -165,6 +167,7 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
 
 // DeleteCStorVolumeAttachmentCR removes the CStorVolumeAttachmentCR for the specified path
 func DeleteCStorVolumeAttachmentCR(csivolName string) error {
+	logrus.Infof("Deleting cva %s", csivolName)
 	return csivolume.NewKubeclient().
 		WithNamespace(OpenEBSNamespace).Delete(csivolName)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -360,6 +360,7 @@ func Cleanup() (err error) {
 		time.Sleep(time.Second)
 		count++
 		if count == 5 {
+			logrus.Errorf("Failed to get cva list, err: %v", err)
 			return
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -375,6 +375,7 @@ func Cleanup() (err error) {
 			logrus.Infof("Cleaning up %s from node", vol.Spec.Volume.Name)
 			if err := iscsiutils.UnmountAndDetachDisk(vol, vol.Spec.Volume.StagingTargetPath); err == nil {
 				vol.Finalizers = nil
+				logrus.Infof("Cleaning up cva %s", vol.Name)
 				if vol, err = UpdateCStorVolumeAttachmentCR(vol); err != nil {
 					logrus.Errorf(err.Error())
 				}


### PR DESCRIPTION
This PR addresses the following:
1. Handle clean up errors on node restarts
2. Monitor and remove stale cstorVolumeAttachment objects. To handle cases when kubelet doesn't send unstage requests on node reboots.
3. Avoid patching nodeID to CVC object every time the volume is staged. This may cause issues when the application pod is moved to a new node. Updating CVC requires the admission server to be reachable.
4. Improve logging 
Signed-off-by: Payes Anand <payes.anand@mayadata.io>
