### PR TITLE
fix(mount): allow staging of cStor volume only from one node

### DIFF
--- a/pkg/kubernetes/node/kubernetes.go
+++ b/pkg/kubernetes/node/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	client "github.com/openebs/cstor-csi/pkg/kubernetes/client"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -170,4 +171,21 @@ func GetOSAndKernelVersion() (string, error) {
 	}
 	nodedetails := firstNode.Items[0].Status.NodeInfo
 	return nodedetails.OSImage + ", " + nodedetails.KernelVersion, nil
+}
+
+// IsNodeReady will return true if node has KubeletReady condition
+// set to true else return false
+func IsNodeReady(nodeName string) (bool, error) {
+	node, err := NewKubeClient().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == v1.NodeReady {
+			if cond.Status == v1.ConditionTrue {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
**What this PR does**:
This PR allows discovery & login to iSCSI volume only from one node at any given time.

This PR handles below case:
- Only one pod will get an iSCSI volume if multiple pods
instances consume the same volume from different nodes at any time.

Limitations:
- If multiple pod instances of different nodes perform NodeStaging
  request same time then both will succeed in the operation but only
  one can perform IOs.
- Canary deployments model & Rolling update strategy deployment will
  not work as-is(As a workaround old pods needs to be deleted) they
  will remain in a pending state.
- Multiple pod instances of same (or) different deployments can run on same
  node(If we add checks then the rolling update strategy will never work).

NOTE:
- To avoid limitation 1 we need to add check-in istgt code base if
  the connection already exist & active then don't allow new connection.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/openebs/openebs/issues/3404 (It only fixes partial part of issue)


**Special notes for your reviewer**:
- It only fixes partial part of openebs/openebs#3404
- It has limitations as mentioned above

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>