### PR TITLE
chore(operator): bump k8s csi sidecars images

### DIFF
--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -968,7 +968,7 @@ spec:
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -998,7 +998,7 @@ spec:
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -1031,7 +1031,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-health-monitor-controller
-          image: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.4.0
+          image: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
           imagePullPolicy: Always
           args:
             - "--v=5"
@@ -1251,7 +1251,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"


### PR DESCRIPTION
**What this PR does**:

Update the k8s csi sidecar images to support minimum k8s 1.18+ version.

- CSI Provisioner:
k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0


- CSI Resizer:
k8s.gcr.io/sig-storage/csi-resizer:v1.2.0

- CSI Node Driver Registrar
k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0

- CSI Volume Monitor
k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0

**Note**:  Keeping the Snapshotter version as same as earlier , since the latest version only support the V1 snaphot apis , and cloud k8s distribution, openshift etc does not supported the v1 snapshot APIs yet.

With current snapshotter 3.0.3 version we have advantage that it will support both v1beta1/v1 apis, which will work in most of the cloud/openshift
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>