### PR TITLE
fix(graceful node stage): Add sleep timer to avoid simultaneous creation and deletion of resource

### DIFF
--- a/pkg/driver/node_utils.go
+++ b/pkg/driver/node_utils.go
@@ -409,7 +409,7 @@ func (ns *node) prepareVolumeForNode(
 		return err
 	}
 
-	if err = utils.DeleteOldCStorVolumeAttachmentCRs(volumeID); err != nil {
+	if err = utils.DeleteOldCStorVolumeAttachmentCRs(volumeID, nodeID); err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
 	if err = utils.CreateCStorVolumeAttachmentCR(vol, nodeID); err != nil {

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -15,17 +15,20 @@
 package utils
 
 import (
+	"strings"
 	"time"
 
 	apis "github.com/openebs/api/v3/pkg/apis/cstor/v1"
+	errors "github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	csv "github.com/openebs/cstor-csi/pkg/cstor/volume"
 	csivolume "github.com/openebs/cstor-csi/pkg/cstor/volumeattachment"
 	node "github.com/openebs/cstor-csi/pkg/kubernetes/node"
 	pv "github.com/openebs/cstor-csi/pkg/kubernetes/persistentvolume"
-	errors "github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -37,6 +40,12 @@ const (
 
 	// VOLNAME is the name of the provisioned volume
 	VOLNAME = "Volname"
+)
+
+var (
+	// loopCount is the no of times cStor volume attachment's successful deletion check
+	// will be performed
+	loopCount = 5
 )
 
 // getNodeDetails fetches the nodeInfo for the current node
@@ -147,8 +156,10 @@ func UpdateCStorVolumeAttachmentCR(csivol *apis.CStorVolumeAttachment) (*apis.CS
 // gets deleted or replaced or updated
 
 // DeleteOldCStorVolumeAttachmentCRs removes the CStorVolumeAttachmentCR for the specified path
-func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
-	var isResourceDeleted bool
+func DeleteOldCStorVolumeAttachmentCRs(volumeID, nodeID string) error {
+	// nodeCVA contains the name of the cStor volume attachment for the current node
+	var nodeCVA string
+
 	csivols, err := GetVolList(volumeID)
 	if err != nil {
 		return err
@@ -161,15 +172,35 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
 		if err != nil {
 			return err
 		}
-		isResourceDeleted = true
+
+		// Extract only the CVA which belongs to the current node
+		if strings.Contains(csivol.Name, nodeID) {
+			nodeCVA = csivol.Name
+		}
 	}
 
-	// In Staging request we are making create call immediately after deleting the resource
-	// so to avoid creation of resource when the same named resource is under deleting stage
-	// we are adding sleep for 2secs
-	if isResourceDeleted {
-		time.Sleep(time.Second * 2)
+	if nodeCVA != "" {
+		var err error
+		for i := 1; i <= loopCount; i++ {
+			_, err = csivolume.NewKubeclient().
+				WithNamespace(OpenEBSNamespace).Get(nodeCVA, metav1.GetOptions{})
+			if err != nil {
+				// If the error is an error of type "not found" then break out
+				// of the loop since the deletion is succeeded
+				if k8serrors.IsNotFound(err) {
+					err = nil
+					break
+				}
+			}
+			time.Sleep(1 * time.Second)
+		}
+		// If error still exists, simply log that here. Since the deletion of CVA
+		// will be taken care of its corresponding create request when it happens
+		if err != nil {
+			logrus.Infof("cStor volume attachment: {%v} not deleted. Error: {%v}", nodeCVA, err)
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -174,7 +174,7 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID, nodeID string) error {
 		}
 
 		// Extract only the CVA which belongs to the current node
-		if strings.Contains(csivol.Name, nodeID) {
+		if strings.HasSuffix(csivol.Name, nodeID) {
 			nodeCVA = csivol.Name
 		}
 	}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -165,7 +165,8 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
 	}
 
 	// In Staging request we are making create call immediately after deleting the resource
-	// so to avoid creating resource when the same named resource is deleting stage we are adding sleep
+	// so to avoid creation of resource when the same named resource is under deleting stage
+	// we are adding sleep for 2secs
 	if isResourceDeleted {
 		time.Sleep(time.Second * 2)
 	}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"time"
+
 	apis "github.com/openebs/api/v3/pkg/apis/cstor/v1"
 	csv "github.com/openebs/cstor-csi/pkg/cstor/volume"
 	csivolume "github.com/openebs/cstor-csi/pkg/cstor/volumeattachment"
@@ -146,6 +148,7 @@ func UpdateCStorVolumeAttachmentCR(csivol *apis.CStorVolumeAttachment) (*apis.CS
 
 // DeleteOldCStorVolumeAttachmentCRs removes the CStorVolumeAttachmentCR for the specified path
 func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
+	var isResourceDeleted bool
 	csivols, err := GetVolList(volumeID)
 	if err != nil {
 		return err
@@ -158,6 +161,13 @@ func DeleteOldCStorVolumeAttachmentCRs(volumeID string) error {
 		if err != nil {
 			return err
 		}
+		isResourceDeleted = true
+	}
+
+	// In Staging request we are making create call immediately after deleting the resource
+	// so to avoid creating resource when the same named resource is deleting stage we are adding sleep
+	if isResourceDeleted {
+		time.Sleep(time.Second * 2)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does**:
This PR updates the logic for deleting older cStor volume attachments.

`Background`: Since cva's name are specific to a node/host(i.e volumeID+nodeID) we can easily get any cva present for a particular node.

`Problem`: Due to no wait or check after marking cva's for deletion and simultaneous creation call, the creation of new cva is failing.

`Solution`: To overcome the problem, we'll first fetch only the cva for the concerned node(for the same reason as the name of cva follows a specific pattern) as the creation of cva will happen for that node only which will contain the nodeID. Hence we only need to bother for that one specific cva and the rest can be ignored. Once identifying the cva, we check whether it deleted successfully or not by making `GET` calls to the apiserver and checking for `NotFound` errors for a defined interval of time(5 secs).

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated
