### PR TITLE
cherry-pick(Go version fix): Eliminate difference in go compiler and go.mod version

### DIFF
--- a/buildscripts/cstor-csi-driver/cstor-csi-driver.Dockerfile
+++ b/buildscripts/cstor-csi-driver/cstor-csi-driver.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14.7 as build
+FROM golang:1.16.5 as build
 
 ARG BRANCH
 ARG RELEASE_TAG


### PR DESCRIPTION
cherry-pick: #169 