### PR TITLE
fix(event): set replica count in action replacing wrong content

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -369,7 +369,7 @@ func sendEventOrIgnore(pvcName, pvName, capacity, replicaCount, stgType, method 
 			SetVolumeName(pvName).
 			SetVolumeClaimName(pvcName).
 			SetLabel(analytics.EventLabelCapacity).
-			SetAction(GetReplicaCount(stgType, method)).
+			SetAction(GetReplicaCount(replicaCount, method)).
 			SetCategory(method).
 			SetVolumeCapacity(capacity).Send()
 	}


### PR DESCRIPTION
The event action was getting set to the default cas type instead of the replica count, which is fixed with this.